### PR TITLE
Add package version to the printed output

### DIFF
--- a/ppa-stats
+++ b/ppa-stats
@@ -90,5 +90,5 @@ for binary in binaries:
                           restricting your query with -p, -s, or -a")
         sys.exit()
 
-    print (("%s %s %s %d") % (binary.binary_package_name, series, arch, downloadCount))
+    print (("%s %s %s %s %d") % (binary.binary_package_name, binary.binary_package_version, series, arch, downloadCount))
 


### PR DESCRIPTION
I found that I wanted to have the binary package version included in the results also (so that I could confirm the versions of the actual packages), so I made this small change to do that.